### PR TITLE
Specify tensorflow version

### DIFF
--- a/requirements_colab.txt
+++ b/requirements_colab.txt
@@ -1,3 +1,6 @@
+tensorflow==2.8.0 # The latest should include tensorflow-gpu
+tensorflow-datasets==4.4.0
+tensorflow-addons==0.15.0
 apache-beam==2.34.0
 mediapy==1.0.3
 loguru


### PR DESCRIPTION
Apparently, tensorflow==2.6.2 is no longer working, but 2.8 seems to work fine for now. 